### PR TITLE
feat: add `getFieldName` to context of `render()`

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,11 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec';
-import { Suspense, createContext, useCallback, useContext } from 'react';
+import {
+  Suspense,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+} from 'react';
 import type {
   DefineFieldOptions,
   DefineFieldRenderContext,
@@ -47,12 +53,22 @@ export function defineField<TProps extends object = object>() {
     TProps
   > {
     const { name, schema, getDefaultValues, render, fallback } = options;
-    const context: DefineFieldRenderContext<TSchema, TFieldName> = {
-      name,
-      schema,
-    };
 
     const FieldContent = (props: TProps) => {
+      const getFieldName = useFieldName({
+        name,
+        schema,
+      });
+
+      const context: DefineFieldRenderContext<TSchema, TFieldName> = useMemo(
+        () => ({
+          name,
+          schema,
+          getFieldName,
+        }),
+        [getFieldName],
+      );
+
       return <>{render(context, props)}</>;
     };
 
@@ -89,7 +105,10 @@ export function defineField<TProps extends object = object>() {
 }
 
 export function useFieldName<
-  TDefineFieldRenderContext extends DefineFieldRenderContext<any, any>,
+  TDefineFieldRenderContext extends Omit<
+    DefineFieldRenderContext<any, any>,
+    'getFieldName'
+  >,
 >(context: TDefineFieldRenderContext) {
   const { name } = useContext(FieldNameContext);
 
@@ -105,7 +124,4 @@ export function useFieldName<
     : never;
 }
 
-export type {
-  InferFieldShape,
-  InferFieldSchema,
-} from './types';
+export type { InferFieldShape, InferFieldSchema } from './types';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,5 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec';
-import {
-  Suspense,
-  createContext,
-  useCallback,
-  useContext,
-  useMemo,
-} from 'react';
+import { Suspense, createContext, useCallback, useContext } from 'react';
 import type {
   DefineFieldOptions,
   DefineFieldRenderContext,
@@ -60,14 +54,11 @@ export function defineField<TProps extends object = object>() {
         schema,
       });
 
-      const context: DefineFieldRenderContext<TSchema, TFieldName> = useMemo(
-        () => ({
-          name,
-          schema,
-          getFieldName,
-        }),
-        [getFieldName],
-      );
+      const context: DefineFieldRenderContext<TSchema, TFieldName> = {
+        name,
+        schema,
+        getFieldName,
+      };
 
       return <>{render(context, props)}</>;
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,10 @@ export interface DefineFieldRenderContext<
 > {
   name: TFieldName;
   schema: TSchema;
+  getFieldName: FieldNameHelper<
+    TFieldName,
+    StandardSchemaV1.InferOutput<TSchema>
+  >;
 }
 
 export interface DefineFieldOptions<


### PR DESCRIPTION
## Description

context를 통해 name()에 접근할 수 있도록 수정했어요.

## Context

`name` 함수를 자주 사용하는 만큼 `useFieldName`을 import 할 필요 없이 context에서 바로 쓸 수 있도록 해요.

## Example

```diff typescript
defineField()({
  name: "field",
  schema: z.object({}),
  render: (context) => {
-   const name = useFieldName();
+   const name = context.getFieldName();

    return (
      <FormField
        name={name()}
        render={({ field }) => 
          // ...
        }
      />
    );
  }
});
```