### PR TITLE
Fix/implement get field name inside field content

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,11 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec';
-import { Suspense, createContext, useCallback, useContext } from 'react';
+import {
+  Suspense,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+} from 'react';
 import type {
   DefineFieldOptions,
   DefineFieldRenderContext,
@@ -52,16 +58,19 @@ export function defineField<TProps extends object = object>() {
       const { name: parentFieldName } = useContext(FieldNameContext);
       const baseName = parentFieldName ?? name;
 
-      const getFieldName = useCallback(
-        (fieldName: string) => [baseName, fieldName].filter(Boolean).join('.'),
-        [baseName],
-      ) as FieldNameHelper<TFieldName, StandardSchemaV1.InferOutput<TSchema>>;
+      const context = useMemo(() => {
+        const getFieldName: FieldNameHelper<
+          TFieldName,
+          StandardSchemaV1.InferOutput<TSchema>
+        > = (fieldName?: TFieldName) =>
+          [baseName, fieldName].filter(Boolean).join('.') as never;
 
-      const context: DefineFieldRenderContext<TSchema, TFieldName> = {
-        name,
-        schema,
-        getFieldName,
-      };
+        return {
+          name,
+          schema,
+          getFieldName,
+        } satisfies DefineFieldRenderContext<TSchema, TFieldName>;
+      }, [baseName]);
 
       return <>{render(context, props)}</>;
     };
@@ -99,7 +108,7 @@ export function defineField<TProps extends object = object>() {
 }
 
 /**
- * @deprecated `useFieldName()` is deprecated. Use `context.getFieldName()` instead.
+ * @deprecated No longer needed. `getFieldName` is now internalized in `defineField`.
  */
 export function useFieldName<
   TDefineFieldRenderContext extends Omit<


### PR DESCRIPTION
## Description

- `<FieldContent />` 내부에서 `useFieldName`를 사용하는 대신 직접 구현하는 형태로 변경했어요.
- context를 메모이즈 했어요.
- 다음과 같은 영향이 있어요.
  - **context의 참조 안정성 증가**: context를 dependency array에 넣어도 안전해져요.
  - **코드 정리가 쉬워짐**: 추후 useFieldName 훅을 제거하기 용이해져요.
- deprecation comment 오타 수정